### PR TITLE
fix(session): fix early update of stack index

### DIFF
--- a/src/runtime/session/History.ts
+++ b/src/runtime/session/History.ts
@@ -67,8 +67,8 @@ class HistoryInternal {
 
         addEventListener("popstate", (event) => {
             const previous = this._stack[this._index];
-            this._index = event.state?.index ?? 0;
-            const current = this._stack[this._index];
+            const nextIndex = event.state?.index ?? 0;
+            const current = this._stack[nextIndex];
 
             if (previous === undefined || current === undefined) {
                 return;
@@ -82,6 +82,8 @@ class HistoryInternal {
             if (isUrlForSameDocument(previousUrl, location.href)) {
                 return;
             }
+
+            this._index = nextIndex;
 
             event.preventDefault();
 


### PR DESCRIPTION
The current stack index was updated before the decision to handle the popstate event, corrupting the history.

Navigation from one page to a second, then to an internal anchor and finally to a second another internal anchor would take use back to the initial page with a browser url of the second page with the second anchor.