### PR TITLE
change dist files organisation

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -178,8 +178,12 @@ export class FrugalConfig {
         return new URL(".cache/", this.outdir);
     }
 
+    get tempdir() {
+        return new URL(".temp/", this.outdir);
+    }
+
     get builddir() {
-        return new URL("build/", this.cachedir);
+        return new URL("build/", this.tempdir);
     }
 
     get buildCacheFile() {

--- a/src/build/plugins/cleanOutdir.ts
+++ b/src/build/plugins/cleanOutdir.ts
@@ -30,15 +30,13 @@ export function cleanOutdir(config: FrugalConfig, cleanAll: boolean): esbuild.Pl
                         );
 
                         for await (const entry of Deno.readDir(config.outdir)) {
-                            if (entry.name !== ".cache") {
-                                await Deno.remove(new URL(entry.name, config.outdir), {
+                            const entryURL = new URL(entry.name, config.outdir);
+                            if (!entry.isDirectory || `${entryURL.href}/` !== config.cachedir.href) {
+                                await Deno.remove(entryURL, {
                                     recursive: true,
                                 });
                             }
                         }
-                        await Deno.remove(esbuildOutDir, {
-                            recursive: true,
-                        });
                     } else {
                         log(
                             `clean directory ${esbuildOutDir}`,

--- a/src/cache/BuildCache.ts
+++ b/src/cache/BuildCache.ts
@@ -77,6 +77,7 @@ export class BuildCache implements Cache {
     async save() {
         const filePath = path.fromFileUrl(this.#config.buildCacheFile);
 
+        await fs.ensureFile(filePath);
         await Deno.writeTextFile(
             filePath,
             JSON.stringify({ current: this.#current, previous: this.#previous }, undefined, 2),

--- a/src/plugin/script.ts
+++ b/src/plugin/script.ts
@@ -46,7 +46,7 @@ export function script(
                     for (const asset of assets) {
                         const entrypoint = asset.entrypoint;
                         const facadePath = path.join("asset", "script", entrypoint);
-                        const facadeUrl = new URL(facadePath, frugal.config.cachedir);
+                        const facadeUrl = new URL(facadePath, frugal.config.tempdir);
                         const facadeContent = `import "${asset.url.href}";`;
                         facadesMap[entrypoint] = facadesMap[entrypoint] ?? {
                             entrypoint,


### PR DESCRIPTION
`.cache` for files that should persist between build (like buildcache, or google fonts)
`.temp` for temporary files that can be deleted between builds (the server bundle outputed by esbuild, or the facade for script bundling)